### PR TITLE
missing trailing word 'element'

### DIFF
--- a/Snippets/French/MinkSteps/thenIShouldSeeTextInElement_bis.sublime-snippet
+++ b/Snippets/French/MinkSteps/thenIShouldSeeTextInElement_bis.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[Then I should see "${1:<text>}" in the "${2:<element>}"]]></content>
+    <content><![CDATA[Then I should see "${1:<text>}" in the "${2:<element>}" element]]></content>
     <tabTrigger>tie</tabTrigger>
-    <description>Then I should see "text" in the "element"</description>
+    <description>Then I should see "text" in the "element" element</description>
 </snippet>


### PR DESCRIPTION
Behat syntax for this requires the word 'element' at the end
